### PR TITLE
Changed zimbra.service: Type to "forking"

### DIFF
--- a/zimbra.service
+++ b/zimbra.service
@@ -6,9 +6,10 @@ After=syslog.target network.target
 Conflicts=sendmail.service exim.service postfix.service
 
 [Service]
-Type=simple
+Type=forking
 User=zimbra
 Group=zimbra
+Environment=PERL5LIB=/opt/zimbra/common/lib/perl5/x86_64-linux-gnu-thread-multi:/opt/zimbra/common/lib/perl5
 ExecStart=/opt/zimbra/bin/zmcontrol start
 ExecStop=/opt/zimbra/bin/zmcontrol stop
 ExecReload=/opt/zimbra/bin/zmcontrol restart


### PR DESCRIPTION
Keeps systemd from stopping the service, because zmcontrol forks the processes into background.
Setting PERL5LIB environment was necessary for amavis.

Fixes #4 