### PR TITLE
corrected Recipient quota from domain wide to user@domain

### DIFF
--- a/cbpolicyd.sh
+++ b/cbpolicyd.sh
@@ -101,7 +101,7 @@ cat <<EOF > "${POLICYDPOLICYSQL}"
 INSERT INTO policies (ID, Name,Priority,Description) VALUES(6, 'Zimbra CBPolicyd Policies', 0, 'Zimbra CBPolicyd Policies');
 INSERT INTO policy_members (PolicyID,Source,Destination) VALUES(6, 'any', 'any');
 INSERT INTO quotas (PolicyID,Name,Track,Period,Verdict,Data) VALUES (6, 'Sender:user@domain','Sender:user@domain', 60, 'DEFER', 'You are sending too many emails, contact helpdesk');
-INSERT INTO quotas (PolicyID,Name,Track,Period,Verdict) VALUES (6, 'Recipient:@domain', 'Recipient:@domain', 60, 'REJECT');
+INSERT INTO quotas (PolicyID,Name,Track,Period,Verdict) VALUES (6, 'Recipient:user@domain', 'Recipient:user@domain', 60, 'REJECT');
 INSERT INTO quotas_limits (QuotasID,Type,CounterLimit) VALUES(3, 'MessageCount', 100);
 INSERT INTO quotas_limits (QuotasID,Type,CounterLimit) VALUES(4, 'MessageCount', 125);
 EOF


### PR DESCRIPTION
Currently the quota for receiver is not doing what's described at https://blog.zimbra.com/2020/03/2-3-zimbra-open-core-series-rate-limiting-email-with-policyd/ :

> Rate limit anyone from receiving more then 125 emails in a 60 second period. Messages beyond this rate are rejected.

Instead, it's a domain wide restriction: meaning that you are limiting whole domain rate of receiving e-mail.

This PR fixes that by setting recipient in place of domain.